### PR TITLE
Ore plugin deployment

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,9 @@ indra-licenserSpotless = { module = "net.kyori:indra-licenser-spotless", version
 # plugin-development
 pluginMeta = { module = "org.spongepowered:plugin-meta", version = "0.8.0"}
 
+# ore
+apacheHttp-client = { module = "org.apache.httpcomponents.client5:httpclient5", version = "5.1.3"}
+
 [plugins]
 gradlePluginPublish = { id = "com.gradle.plugin-publish", version.ref = "pluginPublish" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/ore/build.gradle.kts
+++ b/ore/build.gradle.kts
@@ -1,0 +1,21 @@
+dependencies {
+    api(libs.mammoth)
+    implementation(libs.gson)
+    implementation(libs.apacheHttp.client)
+}
+
+sourceSets.main {
+    multirelease {
+        alternateVersions(9)
+    }
+}
+
+indraPluginPublishing {
+    plugin(
+        "ore",
+        "org.spongepowered.gradle.ore.OreDeploymentPlugin",
+        "Ore Deployment",
+        "Deploy Sponge plugins to the Ore plugin repository",
+        listOf("ore", "publishing", "sponge", "minecraft", "plugin")
+    )
+}

--- a/ore/build.gradle.kts
+++ b/ore/build.gradle.kts
@@ -1,5 +1,14 @@
+plugins {
+    groovy
+}
+
+tasks.withType(GroovyCompile::class).configureEach {
+    options.compilerArgs.add("-Xlint:all")
+}
+
 dependencies {
     api(libs.mammoth)
+    implementation(localGroovy())
     implementation(libs.gson)
     implementation(libs.apacheHttp.client)
 }

--- a/ore/src/main/groovy/org/spongepowered/gradle/ore/OreDeploymentPlugin.java
+++ b/ore/src/main/groovy/org/spongepowered/gradle/ore/OreDeploymentPlugin.java
@@ -72,6 +72,7 @@ public class OreDeploymentPlugin implements ProjectPlugin {
         });
 
         this.registerPublicationTasks(extension, tasks);
+        this.registerDefaultPublication(project, extension);
 
         tasks.register("orePermissions", ViewOrePermissions.class, task -> {
             task.setGroup(HelpTasksPlugin.HELP_GROUP);
@@ -92,8 +93,8 @@ public class OreDeploymentPlugin implements ProjectPlugin {
         });
     }
 
-    private void registerDefaultPublication(final OreDeploymentExtension extension, final PluginContainer plugins) {
-        // todo: grab plugin ID from SG?
+    private void registerDefaultPublication(final Project project, final OreDeploymentExtension extension) {
+        SpongeGradleConfigurationSource.configureSpongeGradle(project, extension);
     }
 
     private String publishTaskName(final String publicationName) {

--- a/ore/src/main/groovy/org/spongepowered/gradle/ore/SpongeGradleConfigurationSource.groovy
+++ b/ore/src/main/groovy/org/spongepowered/gradle/ore/SpongeGradleConfigurationSource.groovy
@@ -24,8 +24,10 @@
  */
 package org.spongepowered.gradle.ore
 
+import groovy.transform.PackageScope
 import org.gradle.api.Project
 
+@PackageScope
 class SpongeGradleConfigurationSource {
 
     private SpongeGradleConfigurationSource() {

--- a/ore/src/main/groovy/org/spongepowered/gradle/ore/SpongeGradleConfigurationSource.groovy
+++ b/ore/src/main/groovy/org/spongepowered/gradle/ore/SpongeGradleConfigurationSource.groovy
@@ -1,0 +1,48 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore
+
+import org.gradle.api.Project
+
+class SpongeGradleConfigurationSource {
+
+    private SpongeGradleConfigurationSource() {
+    }
+
+    static def configureSpongeGradle(Project project, OreDeploymentExtension extension) {
+        project.plugins.withId('org.spongepowered.gradle.plugin') {
+            def first = true
+            project.sponge.plugins.whenObjectAdded { plugin ->
+                if (first) {
+                    first = false
+                    extension.defaultPublication {
+                        projectId.set(plugin.name)
+                        publishArtifacts.from(project.tasks.named('jar').map { it.outputs })
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentExtension.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentExtension.java
@@ -27,7 +27,7 @@ package org.spongepowered.gradle.ore;
 import static java.util.Objects.requireNonNull;
 
 import org.gradle.api.Action;
-import org.gradle.api.NamedDomainObjectCollection;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.NotNull;
 
@@ -93,14 +93,14 @@ public interface OreDeploymentExtension {
      * @return publications collection
      * @since 2.1.0
      */
-    @NotNull NamedDomainObjectCollection<OrePublication> publications();
+    @NotNull NamedDomainObjectContainer<OrePublication> publications();
 
     /**
      * Configure the publications on this project.
      *
      * @param configureAction the configure action
      */
-    default void publications(final @NotNull Action<NamedDomainObjectCollection<OrePublication>> configureAction) {
+    default void publications(final @NotNull Action<NamedDomainObjectContainer<OrePublication>> configureAction) {
         requireNonNull(configureAction, "configureAction").execute(this.publications());
     }
 

--- a/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentExtension.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentExtension.java
@@ -30,6 +30,7 @@ import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.provider.Property;
 import org.jetbrains.annotations.NotNull;
+import org.spongepowered.gradle.ore.internal.OrePublicationImpl;
 
 /**
  * Properties to configure all ore deployment tasks.
@@ -88,6 +89,22 @@ public interface OreDeploymentExtension {
     }
 
     /**
+     * Configure the default publication, creating it if necessary.
+     *
+     * <p>This publication will be automatically configured when SpongeGradle is present.</p>
+     *
+     * @param configureAction the action to configure
+     * @since 2.1.0
+     */
+    default void defaultPublication(final @NotNull Action<? super OrePublication> configureAction) {
+        if (this.publications().getNames().contains(OrePublicationImpl.DEFAULT_NAME)) {
+            this.publications().named(OrePublicationImpl.DEFAULT_NAME).configure(configureAction);
+        } else {
+            this.publications().register(OrePublicationImpl.DEFAULT_NAME, configureAction);
+        }
+    }
+
+    /**
      * Get publications for this project.
      *
      * @return publications collection
@@ -99,6 +116,7 @@ public interface OreDeploymentExtension {
      * Configure the publications on this project.
      *
      * @param configureAction the configure action
+     * @since 2.1.0
      */
     default void publications(final @NotNull Action<NamedDomainObjectContainer<OrePublication>> configureAction) {
         requireNonNull(configureAction, "configureAction").execute(this.publications());

--- a/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentExtension.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentExtension.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore;
+
+import static java.util.Objects.requireNonNull;
+
+import org.gradle.api.Action;
+import org.gradle.api.NamedDomainObjectCollection;
+import org.gradle.api.provider.Property;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Properties to configure all ore deployment tasks.
+ *
+ * <p>These options can be overridden per-task if needed.</p>
+ *
+ * @since 2.1.0
+ */
+public interface OreDeploymentExtension {
+
+    /**
+     * The Ore host to publish to.
+     *
+     * <p>Default: {@code https://ore.spongepowered.org/}</p>
+     *
+     * @return a property supplying the ore endpoint.
+     * @since 2.1.0
+     */
+    @NotNull Property<String> oreEndpoint();
+
+    /**
+     * Set the ore host to publish to.
+     *
+     * @param endpoint the ore endpoint
+     * @since 2.1.0
+     * @see #oreEndpoint()
+     */
+    default void oreEndpoint(final @NotNull String endpoint) {
+        this.oreEndpoint().set(endpoint);
+    }
+
+    /**
+     * Get the API key to use for authentication.
+     *
+     * <p>This should be a v2 API key with {@code create_version} permissions.</p>
+     *
+     * <p>For security reasons, this property should be set to the value of a gradle property
+     * or environment variable rather than the literal API key.</p>
+     *
+     * <p>Default: the value of the environment variable {@code ORE_TOKEN}.</p>
+     *
+     * @return the API key property
+     * @since 2.1.0
+     */
+    @NotNull Property<String> apiKey();
+
+    /**
+     * Set the API key to use for authentication.
+     *
+     * @param apiKey the api key
+     * @since 2.1.0
+     * @see #apiKey()
+     */
+    default void apiKey(final @NotNull String apiKey) {
+        this.apiKey().set(apiKey);
+    }
+
+    /**
+     * Get publications for this project.
+     *
+     * @return publications collection
+     * @since 2.1.0
+     */
+    @NotNull NamedDomainObjectCollection<OrePublication> publications();
+
+    /**
+     * Configure the publications on this project.
+     *
+     * @param configureAction the configure action
+     */
+    default void publications(final @NotNull Action<NamedDomainObjectCollection<OrePublication>> configureAction) {
+        requireNonNull(configureAction, "configureAction").execute(this.publications());
+    }
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentPlugin.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentPlugin.java
@@ -27,14 +27,17 @@ package org.spongepowered.gradle.ore;
 import net.kyori.mammoth.ProjectPlugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.HelpTasksPlugin;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.publish.plugins.PublishingPlugin;
 import org.gradle.api.tasks.TaskContainer;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.gradle.ore.internal.OreDeploymentExtensionImpl;
 import org.spongepowered.gradle.ore.internal.OreSessionService;
 import org.spongepowered.gradle.ore.task.OreTask;
 import org.spongepowered.gradle.ore.task.PublishToOreTask;
+import org.spongepowered.gradle.ore.task.ViewOrePermissions;
 
 import java.time.Duration;
 
@@ -42,6 +45,8 @@ public class OreDeploymentPlugin implements ProjectPlugin {
 
     private static final String ORE_DEPLOYMENT_EXTENSION = "oreDeployment";
     private static final String PUBLISH_TO_ORE_TASK = "publishToOre";
+
+    private static final String ORE_GROUP = "ore";
 
     @Override
     public void apply(
@@ -68,16 +73,21 @@ public class OreDeploymentPlugin implements ProjectPlugin {
 
         this.registerPublicationTasks(extension, tasks);
 
+        tasks.register("orePermissions", ViewOrePermissions.class, task -> {
+            task.setGroup(HelpTasksPlugin.HELP_GROUP);
+        });
     }
 
     private void registerPublicationTasks(final OreDeploymentExtension extension, final TaskContainer tasks) {
         tasks.register(PUBLISH_TO_ORE_TASK, task -> {
             task.dependsOn(tasks.withType(PublishToOreTask.class));
+            task.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
         });
 
         extension.publications().all(publication -> {
             tasks.register(publishTaskName(publication.getName()), PublishToOreTask.class, task -> {
                 task.getPublication().set(publication);
+                task.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
             });
         });
     }

--- a/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentPlugin.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentPlugin.java
@@ -36,6 +36,8 @@ import org.spongepowered.gradle.ore.internal.OreSessionService;
 import org.spongepowered.gradle.ore.task.OreTask;
 import org.spongepowered.gradle.ore.task.PublishToOreTask;
 
+import java.time.Duration;
+
 public class OreDeploymentPlugin implements ProjectPlugin {
 
     private static final String ORE_DEPLOYMENT_EXTENSION = "oreDeployment";
@@ -54,7 +56,7 @@ public class OreDeploymentPlugin implements ProjectPlugin {
             "oreSessions",
             OreSessionService.class,
             params -> {
-                // todo: session expiration
+                params.getParameters().getSessionDuration().set(Duration.ofHours(3));
             }
         );
 

--- a/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentPlugin.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/OreDeploymentPlugin.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore;
+
+import net.kyori.mammoth.ProjectPlugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.PluginContainer;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskContainer;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.gradle.ore.internal.OreDeploymentExtensionImpl;
+import org.spongepowered.gradle.ore.internal.OreSessionService;
+import org.spongepowered.gradle.ore.task.OreTask;
+import org.spongepowered.gradle.ore.task.PublishToOreTask;
+
+public class OreDeploymentPlugin implements ProjectPlugin {
+
+    private static final String ORE_DEPLOYMENT_EXTENSION = "oreDeployment";
+    private static final String PUBLISH_TO_ORE_TASK = "publishToOre";
+
+    @Override
+    public void apply(
+        final @NotNull Project project,
+        final @NotNull PluginContainer plugins,
+        final @NotNull ExtensionContainer extensions,
+        final @NotNull TaskContainer tasks
+    ) {
+        final OreDeploymentExtension extension = extensions.create(OreDeploymentExtension.class, ORE_DEPLOYMENT_EXTENSION, OreDeploymentExtensionImpl.class);
+
+        final Provider<OreSessionService> ore = project.getGradle().getSharedServices().registerIfAbsent(
+            "oreSessions",
+            OreSessionService.class,
+            params -> {
+                // todo: session expiration
+            }
+        );
+
+        tasks.withType(OreTask.class).configureEach(task -> {
+            task.getOreSessions().set(ore);
+            task.getOreEndpoint().set(extension.oreEndpoint());
+            task.getOreApiKey().set(extension.apiKey());
+        });
+
+        this.registerPublicationTasks(extension, tasks);
+
+    }
+
+    private void registerPublicationTasks(final OreDeploymentExtension extension, final TaskContainer tasks) {
+        tasks.register(PUBLISH_TO_ORE_TASK, task -> {
+            task.dependsOn(tasks.withType(PublishToOreTask.class));
+        });
+
+        extension.publications().all(publication -> {
+            tasks.register(publishTaskName(publication.getName()), PublishToOreTask.class, task -> {
+                task.getPublication().set(publication);
+            });
+        });
+    }
+
+    private void registerDefaultPublication(final OreDeploymentExtension extension, final PluginContainer plugins) {
+        // todo: grab plugin ID from SG?
+    }
+
+    private String publishTaskName(final String publicationName) {
+        final String capitalized;
+        if (publicationName.length() > 0 && Character.isLowerCase(publicationName.codePointAt(0))) {
+            final StringBuilder builder = new StringBuilder(publicationName.length());
+            capitalized = builder.appendCodePoint(Character.toUpperCase(publicationName.codePointAt(0)))
+                .append(publicationName, builder.length(), publicationName.length())
+                .toString();
+        } else {
+            capitalized = publicationName;
+        }
+        return "publish" + capitalized + "PublicationToOre";
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/OrePublication.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/OrePublication.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore;
+
+import org.gradle.api.Named;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.IgnoreEmptyDirectories;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.jetbrains.annotations.NotNull;
+
+// Data that could be applied to a single ore task, or multiple
+public interface OrePublication extends Named {
+
+    @Override
+    @Internal
+    @NotNull String getName();
+
+    /**
+     * The project ID to publish to.
+     *
+     * @return the project ID property
+     * @since 2.1.0
+     */
+    @Input
+    Property<String> getProjectId();
+
+    /**
+     * Get whether a forum post should be created for this project.
+     *
+     * <p>Default: {@code true}</p>
+     *
+     * @return the property for creating a forum post
+     * @since 2.1.0
+     */
+    @Input
+    Property<Boolean> getCreateForumPost();
+
+    /**
+     * Get contents to provide as the body/changelog for a published version.
+     *
+     * <p>Default: (empty)</p>
+     *
+     * @return the body property
+     * @since 2.1.0
+     */
+    @Input
+    Property<String> getVersionBody();
+
+    /**
+     * Get the channel to publish a release to.
+     *
+     * @return the release channel.
+     * @since 2.1.0
+     */
+    @Input
+    @Optional
+    Property<String> getChannel();
+
+    /**
+     * Get the artifact to publish.
+     *
+     * <p>This must evaluate to a single file.</p>
+     *
+     * <p>Default: the output of the project's {@code jar} task</p>
+     *
+     * @return the artifact collection
+     * @since 2.1.0
+     */
+    @InputFiles
+    @SkipWhenEmpty
+    @IgnoreEmptyDirectories
+    ConfigurableFileCollection getPublishArtifacts();
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreDeploymentExtensionImpl.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreDeploymentExtensionImpl.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.gradle.ore.internal;
 
-import org.gradle.api.NamedDomainObjectCollection;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
@@ -41,7 +41,7 @@ public class OreDeploymentExtensionImpl implements OreDeploymentExtension {
     private final Property<String> oreEndpoint;
     private final Property<String> apiKey;
 
-    private final NamedDomainObjectCollection<OrePublication> publications;
+    private final NamedDomainObjectContainer<OrePublication> publications;
 
     @Inject
     public OreDeploymentExtensionImpl(final ObjectFactory objects, final ProviderFactory providers) {
@@ -68,7 +68,7 @@ public class OreDeploymentExtensionImpl implements OreDeploymentExtension {
     }
 
     @Override
-    public @NotNull NamedDomainObjectCollection<OrePublication> publications() {
+    public @NotNull NamedDomainObjectContainer<OrePublication> publications() {
         return this.publications;
     }
 

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreDeploymentExtensionImpl.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreDeploymentExtensionImpl.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal;
+
+import org.gradle.api.NamedDomainObjectCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.gradle.ore.OreDeploymentExtension;
+import org.spongepowered.gradle.ore.OrePublication;
+
+import javax.inject.Inject;
+
+public class OreDeploymentExtensionImpl implements OreDeploymentExtension {
+
+    private static final String DEFAULT_ENDPOINT = "https://ore.spongepowered.org/";
+    private static final String API_KEY_ENVIRONMENT_VARIABLE = "ORE_TOKEN";
+    private final Property<String> oreEndpoint;
+    private final Property<String> apiKey;
+
+    private final NamedDomainObjectCollection<OrePublication> publications;
+
+    @Inject
+    public OreDeploymentExtensionImpl(final ObjectFactory objects, final ProviderFactory providers) {
+        this.oreEndpoint = objects.property(String.class)
+                .convention(OreDeploymentExtensionImpl.DEFAULT_ENDPOINT);
+
+        this.apiKey = objects.property(String.class)
+                .convention(providers.environmentVariable(OreDeploymentExtensionImpl.API_KEY_ENVIRONMENT_VARIABLE));
+
+        this.publications = objects.domainObjectContainer(
+            OrePublication.class,
+            name -> objects.newInstance(OrePublicationImpl.class, name)
+        );
+    }
+
+    @Override
+    public @NotNull Property<String> oreEndpoint() {
+        return this.oreEndpoint;
+    }
+
+    @Override
+    public @NotNull Property<String> apiKey() {
+        return this.apiKey;
+    }
+
+    @Override
+    public @NotNull NamedDomainObjectCollection<OrePublication> publications() {
+        return this.publications;
+    }
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/OrePublicationImpl.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/OrePublicationImpl.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.gradle.ore.OrePublication;
+
+import javax.inject.Inject;
+
+public class OrePublicationImpl implements OrePublication {
+
+    private final String name;
+    private final Property<String> projectId;
+    private final Property<Boolean> createForumPost;
+    private final Property<String> versionBody;
+    private final Property<String> channel;
+    private final ConfigurableFileCollection publishArtifacts;
+
+    @Inject
+    public OrePublicationImpl(final ObjectFactory objects, final String name) {
+        this.name = name;
+
+        this.projectId = objects.property(String.class);
+        this.createForumPost = objects.property(Boolean.class);
+        this.versionBody = objects.property(String.class);
+        this.channel = objects.property(String.class);
+        this.publishArtifacts = objects.fileCollection();
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return this.name;
+    }
+
+    @Override
+    public Property<String> getProjectId() {
+        return this.projectId;
+    }
+
+    @Override
+    public Property<Boolean> getCreateForumPost() {
+        return this.createForumPost;
+    }
+
+    @Override
+    public Property<String> getVersionBody() {
+        return this.versionBody;
+    }
+
+    @Override
+    public Property<String> getChannel() {
+        return this.channel;
+    }
+
+    @Override
+    public ConfigurableFileCollection getPublishArtifacts() {
+        return this.publishArtifacts;
+    }
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/OrePublicationImpl.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/OrePublicationImpl.java
@@ -34,6 +34,8 @@ import javax.inject.Inject;
 
 public class OrePublicationImpl implements OrePublication {
 
+    public static final String DEFAULT_NAME = "default";
+
     private final String name;
     private final Property<String> projectId;
     private final Property<Boolean> createForumPost;

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/OrePublicationImpl.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/OrePublicationImpl.java
@@ -46,9 +46,9 @@ public class OrePublicationImpl implements OrePublication {
         this.name = name;
 
         this.projectId = objects.property(String.class);
-        this.createForumPost = objects.property(Boolean.class);
-        this.versionBody = objects.property(String.class);
-        this.channel = objects.property(String.class);
+        this.createForumPost = objects.property(Boolean.class).convention(true);
+        this.versionBody = objects.property(String.class).convention("");
+        this.channel = objects.property(String.class).convention("Release");
         this.publishArtifacts = objects.fileCollection();
     }
 

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreResponse.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreResponse.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal;
+
+import org.apache.hc.core5.http.HttpStatus;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Function;
+
+public interface OreResponse<V> {
+
+    static <T> @NotNull Success<T> success(final @Nullable T value) {
+        return new Success<>(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> @NotNull Reauthenticate<T> reauthenticate() {
+        return Reauthenticate.INSTANCE;
+    }
+
+    static <T> @NotNull Failure<T> failure(final int responseCode, final @Nullable String errorMessage) {
+        return new Failure<>(responseCode, errorMessage);
+    }
+
+    boolean wasSuccessful();
+
+    int responseCode();
+
+    <E extends Throwable> Success<V> asSuccessOrThrow(final Function<String, E> errorProvider) throws E;
+
+    final class Success<T> implements OreResponse<T> {
+        private final T value;
+
+        Success(final T value) {
+            this.value = value;
+        }
+
+        public T value() {
+            return this.value;
+        }
+
+        @Override
+        public boolean wasSuccessful() {
+            return true;
+        }
+
+        @Override
+        public int responseCode() {
+            return HttpStatus.SC_OK;
+        }
+
+        @Override
+        public <E extends Throwable> Success<T> asSuccessOrThrow(Function<String, E> errorProvider) {
+            return this;
+        }
+    }
+
+    final class Reauthenticate<T> implements OreResponse<T> {
+
+        @SuppressWarnings("rawtypes")
+        private static final Reauthenticate INSTANCE = new Reauthenticate<>();
+
+
+        private Reauthenticate() {
+        }
+
+        @Override
+        public boolean wasSuccessful() {
+            return false;
+        }
+
+        @Override
+        public int responseCode() {
+            return HttpStatus.SC_UNAUTHORIZED;
+        }
+
+        @Override
+        public <E extends Throwable> Success<T> asSuccessOrThrow(Function<String, E> errorProvider) throws E {
+            throw errorProvider.apply("Session expired!");
+        }
+    }
+
+    final class Failure<T> implements OreResponse<T> {
+        private final int responseCode;
+        private final @Nullable String errorMessage;
+
+        public Failure(int responseCode, @Nullable String errorMessage) {
+            this.responseCode = responseCode;
+            this.errorMessage = errorMessage;
+        }
+
+        public @Nullable String errorMessage() {
+            return this.errorMessage;
+        }
+
+        @Override
+        public boolean wasSuccessful() {
+            return false;
+        }
+
+        @Override
+        public int responseCode() {
+            return this.responseCode;
+        }
+
+        @Override
+        public <E extends Throwable> Success<T> asSuccessOrThrow(Function<String, E> errorProvider) throws E {
+            throw this.errorMessage == null ? errorProvider.apply(String.valueOf(this.responseCode)) : errorProvider.apply(this.errorMessage);
+        }
+    }
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreSession.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreSession.java
@@ -1,0 +1,165 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal;
+
+import com.google.gson.Gson;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.client5.http.entity.mime.FormBodyPartBuilder;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.entity.mime.StringBody;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.nio.AsyncRequestProducer;
+import org.apache.hc.core5.http.nio.entity.NoopEntityConsumer;
+import org.apache.hc.core5.http.nio.support.AsyncRequestBuilder;
+import org.gradle.api.GradleException;
+import org.spongepowered.gradle.ore.internal.http.AsyncLegacyEntityProducer;
+import org.spongepowered.gradle.ore.internal.http.HttpWrapper;
+import org.spongepowered.gradle.ore.internal.http.JsonEntityConsumer;
+import org.spongepowered.gradle.ore.internal.http.JsonEntityProducer;
+import org.spongepowered.gradle.ore.internal.model.ApiSessionProperties;
+import org.spongepowered.gradle.ore.internal.model.AuthenticationResponse;
+import org.spongepowered.gradle.ore.internal.model.DeployVersionInfo;
+import org.spongepowered.gradle.ore.internal.model.Version;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+/**
+ * Represents a session with the Ore API
+ */
+public class OreSession {
+
+    public static final Gson GSON = new Gson();
+
+    private final Executor executor;
+    private final String apiBase;
+    private final String apiKey;
+    private final long sessionDurationSeconds;
+    private CompletableFuture<OreResponse<AuthenticationResponse>> sessionFuture;
+
+    private volatile String sessionKey;
+
+    private final HttpWrapper http = new HttpWrapper(builder -> {
+        builder.addRequestInterceptorFirst((request, entity, context) -> {
+            if (this.sessionKey != null && !request.containsHeader(HttpHeaders.AUTHORIZATION)) {
+                request.setHeader(HttpHeaders.AUTHORIZATION, "OreApi session=\"" + this.sessionKey + "\"");
+            }
+        });
+    });
+
+    public static CompletableFuture<OreSession> connect(final Executor executor, final String apiKey, final String apiBase, final long sessionDurationSeconds) {
+        final OreSession session = new OreSession(executor, apiKey, apiBase, sessionDurationSeconds);
+        return session.authenticate().thenApply(result -> {
+            result.asSuccessOrThrow(RuntimeException::new);
+            return session;
+        });
+    }
+
+    private static URI make(final String apiBase, final String endpoint) {
+        final StringBuilder builder = new StringBuilder(apiBase.length() + endpoint.length());
+        builder.append(apiBase);
+        if (!apiBase.endsWith("/") && !endpoint.startsWith("/")) {
+            builder.append("/");
+        }
+        builder.append(endpoint);
+
+        return URI.create(builder.toString());
+    }
+
+
+    OreSession(final Executor executor, final String apiKey, final String apiBase, final long sessionDurationSeconds) {
+        this.executor = executor;
+        this.apiKey = apiKey;
+        this.apiBase = apiBase;
+        this.sessionDurationSeconds = sessionDurationSeconds;
+    }
+
+    CompletableFuture<OreResponse<AuthenticationResponse>> authenticate() {
+        final AsyncRequestProducer request = AsyncRequestBuilder.get(OreSession.make(this.apiBase, "authenticate"))
+            .setHeader(HttpHeaders.AUTHORIZATION, "OreApi apikey=\"" + this.apiKey + "\"")
+            .setEntity(new JsonEntityProducer(GSON, new ApiSessionProperties(false, this.sessionDurationSeconds)))
+            .build();
+        return this.sessionFuture = this.http.request(request, new JsonEntityConsumer<>(GSON, AuthenticationResponse.class)).thenApply(response -> {
+            if (response.wasSuccessful()) {
+                final AuthenticationResponse auth = response.asSuccessOrThrow(IllegalStateException::new).value();
+                this.sessionKey = auth.session();
+            }
+            return response;
+        });
+    }
+
+    public CompletableFuture<OreResponse<Void>> terminate() {
+        if (this.sessionFuture == null) {
+            return CompletableFuture.completedFuture(OreResponse.failure(404, null));
+        }
+        return this.sessionFuture.thenCompose(session -> {
+            final CompletableFuture<OreResponse<Void>> result = this.http.request(
+                SimpleHttpRequest.create(Method.DELETE, OreSession.make(this.apiBase, "sessions/current")),
+                new NoopEntityConsumer()
+            );
+            this.sessionFuture = null;
+            return result;
+        });
+    }
+
+    public CompletableFuture<Version> publishVersion(final String pluginId, final DeployVersionInfo info, final Path pluginFile) {
+        final HttpEntity entity = MultipartEntityBuilder.create()
+            .addPart(FormBodyPartBuilder.create("plugin-info", new StringBody(GSON.toJson(info), ContentType.APPLICATION_JSON)).build())
+            .addPart(FormBodyPartBuilder.create("plugin-file", new FileBody(pluginFile.toFile())).build())
+            .build();
+
+        return doRequest(() -> this.http.request(
+            AsyncRequestBuilder.post(OreSession.make(this.apiBase, "projects/" + pluginId + "/versions"))
+                .setEntity(new AsyncLegacyEntityProducer(entity, this.executor))
+                .build(),
+            new JsonEntityConsumer<>(GSON, Version.class)
+        ));
+    }
+
+    private <V> CompletableFuture<V> doRequest(final Supplier<CompletableFuture<OreResponse<V>>> action) {
+        return this.sessionFuture.thenCompose(session -> action.get().thenCompose(response -> {
+            if (response instanceof OreResponse.Reauthenticate<?>) {
+                this.authenticate();
+                return this.doRequest(action);
+            } else {
+                final CompletableFuture<V> result = new CompletableFuture<>();
+                if (response instanceof OreResponse.Success<?>) {
+                    result.complete(((OreResponse.Success<V>) response).value());
+                } else {
+                    result.completeExceptionally(new GradleException(((OreResponse.Failure<V>) response).errorMessage()));
+                }
+                return result;
+            }
+        }));
+    }
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreSessionService.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/OreSessionService.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.provider.Property;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public abstract class OreSessionService implements BuildService<OreSessionService.Parameters>, AutoCloseable {
+
+    private static final Logger LOGGER = Logging.getLogger(OreSessionService.class);
+
+    private final ExecutorService executor;
+    private final Map<String, CompletableFuture<OreSession>> sessions = new ConcurrentHashMap<>();
+
+    public OreSessionService() {
+        this.executor = Executors.newCachedThreadPool();
+    }
+
+    public interface Parameters extends BuildServiceParameters {
+        Property<Duration> getSessionDuration();
+    }
+
+    public CompletableFuture<OreSession> session(final String apiKey, final String endpoint) {
+        return sessions.computeIfAbsent(endpoint, end -> OreSession.connect(this.executor, apiKey, end, this.getParameters().getSessionDuration().get().getSeconds()));
+    }
+
+    @Override
+    public void close() {
+        final List<CompletableFuture<?>> futures = new ArrayList<>();
+
+        for (final CompletableFuture<OreSession> session : sessions.values()) {
+            futures.add(session.thenCompose(OreSession::terminate));
+        }
+
+        try {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0])).get();
+        } catch (final InterruptedException | ExecutionException ex) {
+            LOGGER.error("Failed to shut down an ore session", ex);
+        }
+
+        this.executor.shutdown();
+        boolean success;
+        try {
+            success = this.executor.awaitTermination(10, TimeUnit.SECONDS);
+        } catch (final InterruptedException ex) {
+            success = false;
+        }
+
+        if (!success) {
+            LOGGER.warn("Failed to shut down Ore session executor pool in 10 seconds");
+        }
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/AsyncLegacyEntityProducer.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/AsyncLegacyEntityProducer.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.http;
+
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.nio.support.classic.AbstractClassicEntityProducer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.Executor;
+
+public final class AsyncLegacyEntityProducer extends AbstractClassicEntityProducer {
+    private volatile HttpEntity entity;
+
+    public AsyncLegacyEntityProducer(final HttpEntity entity, final Executor executor) {
+        super(8192, ContentType.parse(entity.getContentType()), executor);
+        this.entity = entity;
+    }
+
+    @Override
+    protected void produceData(final ContentType contentType, final OutputStream outputStream) throws IOException {
+        this.entity.writeTo(outputStream);
+    }
+
+    @Override
+    public String getContentEncoding() {
+        return this.entity.getContentEncoding();
+    }
+
+    @Override
+    public void releaseResources() {
+        final HttpEntity entity = this.entity;
+        this.entity = null;
+        if (entity != null) {
+            try {
+                entity.close();
+            } catch (final IOException ex) {
+                this.failed(ex);
+            }
+        }
+        super.releaseResources();
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/FutureToCompletable.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/FutureToCompletable.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.http;
+
+import org.apache.hc.core5.concurrent.FutureCallback;
+
+import java.util.concurrent.CompletableFuture;
+
+final class FutureToCompletable<V> implements FutureCallback<V> {
+    private final CompletableFuture<V> future = new CompletableFuture<>();
+
+    @Override
+    public void completed(final V result) {
+        this.future.complete(result);
+    }
+
+    @Override
+    public void failed(final Exception ex) {
+        this.future.completeExceptionally(ex);
+    }
+
+    @Override
+    public void cancelled() {
+        this.future.cancel(true);
+    }
+
+    CompletableFuture<V> future() {
+        return this.future;
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/HttpWrapper.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/HttpWrapper.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.http;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.AsyncRequestProducer;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.http2.HttpVersionPolicy;
+import org.apache.hc.core5.reactor.IOReactorConfig;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.gradle.util.GradleVersion;
+import org.spongepowered.gradle.ore.internal.OreResponse;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public final class HttpWrapper {
+
+    private final CloseableHttpAsyncClient client;
+    public HttpWrapper(final Consumer<HttpAsyncClientBuilder> builderConfigurer) {
+        // Configure the HTTP client
+        // This won't actually launch a thread pool until the first request is performed.
+        final IOReactorConfig config = IOReactorConfig.custom()
+            .setSoTimeout(Timeout.ofSeconds(5))
+            .build();
+
+        final TlsStrategy tlsStrategy = TlsStrategyProvider.provide();
+        final PoolingAsyncClientConnectionManager cm = PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            .build();
+
+        this.client = HttpAsyncClientBuilder.create()
+            .setIOReactorConfig(config)
+            .setUserAgent("SpongeGradle-Ore/" + this.getClass().getPackage().getImplementationVersion() + " Gradle/" + GradleVersion.current() + " Java/" + System.getProperty("java.version"))
+            .setVersionPolicy(HttpVersionPolicy.NEGOTIATE)
+            .setConnectionManager(cm)
+            .setRetryStrategy(new DefaultHttpRequestRetryStrategy(5, TimeValue.ofMilliseconds(500)))
+            .build();
+    }
+
+    public CloseableHttpAsyncClient client() {
+        this.client.start();
+        return this.client;
+    }
+
+    public <T> CompletableFuture<OreResponse<T>> request(final SimpleHttpRequest request, final AsyncEntityConsumer<T> responseConsumer) {
+        return this.request(SimpleRequestProducer.create(request), responseConsumer);
+    }
+
+    public <T> CompletableFuture<OreResponse<T>> request(final AsyncRequestProducer request, final AsyncEntityConsumer<T> responseConsumer) {
+        final FutureToCompletable<OreResponse<T>> ret = new FutureToCompletable<>();
+        this.client().execute(
+            request,
+            new ToOreResponseConsumer<>(responseConsumer),
+            ret
+        );
+        return ret.future();
+    }
+
+    public <T> CompletableFuture<OreResponse<T>> get(final URI destination, final AsyncEntityConsumer<T> responseConsumer) {
+        return this.request(SimpleHttpRequest.create(Method.GET, destination), responseConsumer);
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/HttpWrapper.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/HttpWrapper.java
@@ -50,6 +50,7 @@ import java.util.function.Consumer;
 public final class HttpWrapper implements AutoCloseable {
 
     private final CloseableHttpAsyncClient client;
+
     public HttpWrapper(final Consumer<HttpAsyncClientBuilder> builderConfigurer) {
         // Configure the HTTP client
         // This won't actually launch a thread pool until the first request is performed.

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/JsonEntityConsumer.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/JsonEntityConsumer.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.http;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.reflect.TypeToken;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.nio.entity.AbstractCharAsyncEntityConsumer;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.CharBuffer;
+
+public final class JsonEntityConsumer<T> extends AbstractCharAsyncEntityConsumer<T> {
+    private final Gson gson;
+    private final Type type;
+
+    private volatile StringBuilder builder = new StringBuilder();
+
+    public JsonEntityConsumer(final Gson gson, final Class<T> type) {
+        this.gson = gson;
+        this.type = type;
+    }
+
+    public JsonEntityConsumer(final Gson gson, final TypeToken<T> token) {
+        this.gson = gson;
+        this.type = token.getType();
+    }
+
+    @Override
+    protected void streamStart(final ContentType contentType) throws HttpException {
+        if (!ContentType.APPLICATION_JSON.equals(contentType)) {
+            throw new HttpException("Incorrect content type received for a json object, expected " + ContentType.APPLICATION_JSON + " but got " + contentType);
+        }
+    }
+
+    @Override
+    protected T generateContent() throws IOException {
+        try {
+            return this.gson.fromJson(this.builder.toString(), this.type);
+        } catch (final JsonParseException ex) {
+            throw new IOException(ex);
+        }
+    }
+
+    @Override
+    protected int capacityIncrement() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    protected void data(final CharBuffer src, final boolean endOfStream) {
+        this.builder.append(src);
+    }
+
+    @Override
+    public void releaseResources() {
+        this.builder = null;
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/JsonEntityConsumer.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/JsonEntityConsumer.java
@@ -53,7 +53,7 @@ public final class JsonEntityConsumer<T> extends AbstractCharAsyncEntityConsumer
 
     @Override
     protected void streamStart(final ContentType contentType) throws HttpException {
-        if (!ContentType.APPLICATION_JSON.equals(contentType)) {
+        if (!ContentType.APPLICATION_JSON.isSameMimeType(contentType)) {
             throw new HttpException("Incorrect content type received for a json object, expected " + ContentType.APPLICATION_JSON + " but got " + contentType);
         }
     }

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/JsonEntityProducer.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/JsonEntityProducer.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.http;
+
+import com.google.gson.Gson;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.nio.StreamChannel;
+import org.apache.hc.core5.http.nio.entity.AbstractCharAsyncEntityProducer;
+
+import java.io.IOException;
+import java.nio.CharBuffer;
+
+public final class JsonEntityProducer extends AbstractCharAsyncEntityProducer {
+    private final Gson gson;
+    private final Object value;
+    private volatile CharBuffer created;
+
+    public JsonEntityProducer(final Gson gson, final Object value) {
+        super(4096, -1, ContentType.APPLICATION_JSON);
+        this.gson = gson;
+        this.value = value;
+    }
+
+    @Override
+    protected int availableData() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    protected void produceData(final StreamChannel<CharBuffer> channel) throws IOException {
+        if (this.created == null) {
+            synchronized (this) {
+                if (this.created == null) {
+                    this.created = CharBuffer.wrap(this.gson.toJson(this.value));
+                }
+            }
+        }
+
+        channel.write(this.created);
+        if (!this.created.hasRemaining()) {
+            channel.endStream();
+        }
+    }
+
+    @Override
+    public boolean isRepeatable() {
+        return true;
+    }
+
+    @Override
+    public void failed(final Exception cause) {
+    }
+
+    @Override
+    public void releaseResources() {
+        this.created = null;
+        super.releaseResources();
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/TlsStrategyProvider.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/TlsStrategyProvider.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.http;
+
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+
+// Has an equivalent in the J9 source set
+final class TlsStrategyProvider {
+
+    private TlsStrategyProvider() {
+    }
+
+    static TlsStrategy provide() {
+        return ClientTlsStrategyBuilder.create()
+                .useSystemProperties()
+                .build();
+    }
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/ToOreResponseConsumer.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/ToOreResponseConsumer.java
@@ -77,15 +77,18 @@ final class ToOreResponseConsumer<V> implements AsyncResponseConsumer<OreRespons
             final AsyncEntityConsumer<V> responseConsumer = Objects.requireNonNull(this.entityConsumerSupplier.get(), "entity consumer");
             this.entityConsumerRef.set(responseConsumer);
 
-            responseConsumer.streamStart(entityDetails, new CallbackContribution<V>(resultCallback) {
-                @Override
-                public void completed(final V result) {
-                    if (resultCallback != null) {
-                        resultCallback.completed(OreResponse.success(result));
+            if (entityDetails != null) {
+                responseConsumer.streamStart(entityDetails, new CallbackContribution<V>(resultCallback) {
+                    @Override
+                    public void completed(final V result) {
+                        if (resultCallback != null) {
+                            resultCallback.completed(OreResponse.success(result));
+                        }
                     }
-                }
-            });
-
+                });
+            } else if (resultCallback != null) {
+                resultCallback.completed(OreResponse.success(null));
+            }
         } else if (code == HttpStatus.SC_UNAUTHORIZED) {
             if (resultCallback != null) {
                 resultCallback.completed(OreResponse.reauthenticate());
@@ -103,6 +106,10 @@ final class ToOreResponseConsumer<V> implements AsyncResponseConsumer<OreRespons
                         }
                     }
                 });
+            } else {
+                if (resultCallback != null) {
+                    resultCallback.completed(OreResponse.failure(code, null));
+                }
             }
         }
     }

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/ToOreResponseConsumer.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/http/ToOreResponseConsumer.java
@@ -1,0 +1,154 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.http;
+
+import org.apache.hc.core5.concurrent.CallbackContribution;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.AsyncResponseConsumer;
+import org.apache.hc.core5.http.nio.CapacityChannel;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.gradle.ore.internal.OreResponse;
+import org.spongepowered.gradle.ore.internal.OreSession;
+import org.spongepowered.gradle.ore.internal.model.ErrorResponse;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Parse the output of a HTTP request into an ore response.
+ *
+ * @param <V> the value type
+ */
+final class ToOreResponseConsumer<V> implements AsyncResponseConsumer<OreResponse<V>> {
+
+    private final Supplier<AsyncEntityConsumer<V>> entityConsumerSupplier;
+    private final AtomicReference<AsyncEntityConsumer<?>> entityConsumerRef = new AtomicReference<>();
+
+    public ToOreResponseConsumer(final Supplier<AsyncEntityConsumer<V>> entityConsumerSupplier) {
+        this.entityConsumerSupplier = entityConsumerSupplier;
+    }
+
+    public ToOreResponseConsumer(final AsyncEntityConsumer<V> consumer) {
+        this.entityConsumerSupplier = () -> consumer;
+    }
+
+    @Override
+    public void consumeResponse(
+        final HttpResponse response,
+        final @Nullable EntityDetails entityDetails,
+        final HttpContext context,
+        final @Nullable FutureCallback<OreResponse<V>> resultCallback
+    ) throws HttpException, IOException {
+        final int code = response.getCode();
+        if (code >= 200 && code < 300) { // ok
+            final AsyncEntityConsumer<V> responseConsumer = Objects.requireNonNull(this.entityConsumerSupplier.get(), "entity consumer");
+            this.entityConsumerRef.set(responseConsumer);
+
+            responseConsumer.streamStart(entityDetails, new CallbackContribution<V>(resultCallback) {
+                @Override
+                public void completed(final V result) {
+                    if (resultCallback != null) {
+                        resultCallback.completed(OreResponse.success(result));
+                    }
+                }
+            });
+
+        } else if (code == HttpStatus.SC_UNAUTHORIZED) {
+            if (resultCallback != null) {
+                resultCallback.completed(OreResponse.reauthenticate());
+            }
+        } else {
+            // error response consumer
+            if (entityDetails != null) {
+                final AsyncEntityConsumer<ErrorResponse> responseConsumer = new JsonEntityConsumer<>(OreSession.GSON, ErrorResponse.class);
+                this.entityConsumerRef.set(responseConsumer);
+                responseConsumer.streamStart(entityDetails, new CallbackContribution<ErrorResponse>(resultCallback) {
+                    @Override
+                    public void completed(final ErrorResponse result) {
+                        if (resultCallback != null) {
+                            resultCallback.completed(OreResponse.failure(code, result == null ? null : result.error()));
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    public void informationResponse(final HttpResponse response, final HttpContext context) {
+    }
+
+    @Override
+    public void failed(final Exception cause) {
+        final AsyncEntityConsumer<?> consumer = this.entityConsumerRef.get();
+        if (consumer != null) {
+            consumer.failed(cause);
+        }
+        this.releaseResources();
+    }
+
+    @Override
+    public void updateCapacity(final CapacityChannel capacityChannel) throws IOException {
+        final AsyncEntityConsumer<?> consumer = this.entityConsumerRef.get();
+        if (consumer != null) {
+            consumer.updateCapacity(capacityChannel);
+        }
+    }
+
+    @Override
+    public void consume(final ByteBuffer src) throws IOException {
+        final AsyncEntityConsumer<?> consumer = this.entityConsumerRef.get();
+        if (consumer != null) {
+            consumer.consume(src);
+        }
+    }
+
+    @Override
+    public void streamEnd(final List<? extends Header> trailers) throws HttpException, IOException {
+        final AsyncEntityConsumer<?> consumer = this.entityConsumerRef.get();
+        if (consumer != null) {
+            consumer.streamEnd(trailers);
+        }
+    }
+
+    @Override
+    public void releaseResources() {
+        final AsyncEntityConsumer<?> consumer = this.entityConsumerRef.getAndSet(null);
+        if (consumer != null) {
+            consumer.releaseResources();
+        }
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/ApiSessionProperties.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/ApiSessionProperties.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.model;
+
+import com.google.gson.annotations.SerializedName;
+
+public class ApiSessionProperties {
+    @SerializedName("_fake")
+    private final boolean fake;
+    @SerializedName("expires_in")
+    private final long expiresIn;
+
+    public ApiSessionProperties(final boolean fake, final long expiresIn) {
+        this.fake = fake;
+        this.expiresIn = expiresIn;
+    }
+
+    public boolean fake() {
+        return this.fake;
+    }
+
+    public long expiresIn() {
+        return this.expiresIn;
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/AuthenticationResponse.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/AuthenticationResponse.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.model;
+
+import java.time.ZonedDateTime;
+
+public class AuthenticationResponse {
+    private final String session;
+    private final ZonedDateTime expires;
+    private final KeyType type;
+
+    public enum KeyType {
+        KEY, USER, PUBLIC, DEV;
+    }
+
+    public AuthenticationResponse(final String session, final ZonedDateTime expires, final KeyType type) {
+        this.session = session;
+        this.expires = expires;
+        this.type = type;
+    }
+
+    public String session() {
+        return this.session;
+    }
+
+    public ZonedDateTime expires() {
+        return this.expires;
+    }
+
+    public KeyType type() {
+        return this.type;
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/AuthenticationResponse.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/AuthenticationResponse.java
@@ -24,18 +24,17 @@
  */
 package org.spongepowered.gradle.ore.internal.model;
 
-import java.time.ZonedDateTime;
 
 public class AuthenticationResponse {
     private final String session;
-    private final ZonedDateTime expires;
+    private final String expires;
     private final KeyType type;
 
     public enum KeyType {
         KEY, USER, PUBLIC, DEV;
     }
 
-    public AuthenticationResponse(final String session, final ZonedDateTime expires, final KeyType type) {
+    public AuthenticationResponse(final String session, final String expires, final KeyType type) {
         this.session = session;
         this.expires = expires;
         this.type = type;
@@ -45,7 +44,7 @@ public class AuthenticationResponse {
         return this.session;
     }
 
-    public ZonedDateTime expires() {
+    public String expires() {
         return this.expires;
     }
 

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/DeployVersionInfo.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/DeployVersionInfo.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.model;
+
+import com.google.gson.annotations.SerializedName;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class DeployVersionInfo {
+
+    public static final String TAG_CHANNEL = "Channel";
+
+    private final String description;
+    @SerializedName("create_forum_post")
+    private final boolean createForumPost;
+    private final Map<String, List<String>> tags;
+
+    public DeployVersionInfo(final String description, final boolean createForumPost, final @Nullable Map<String, List<String>> tags) {
+        this.description = description;
+        this.createForumPost = createForumPost;
+        this.tags = tags == null ? Collections.emptyMap() : tags;
+    }
+
+    public String description() {
+        return this.description;
+    }
+
+    public boolean createForumPost() {
+        return this.createForumPost;
+    }
+
+    public Map<String, List<String>> tags() {
+        return Collections.unmodifiableMap(this.tags);
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/ErrorResponse.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/ErrorResponse.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.model;
+
+import org.jetbrains.annotations.Nullable;
+
+public class ErrorResponse {
+    private final String error;
+    private final int requestId;
+
+    public ErrorResponse(final String error, final int requestId) {
+        this.error = error;
+        this.requestId = requestId;
+    }
+
+    public @Nullable String error() {
+        return this.error;
+    }
+
+    public int requestId() {
+        return this.requestId;
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/ErrorResponse.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/ErrorResponse.java
@@ -24,22 +24,31 @@
  */
 package org.spongepowered.gradle.ore.internal.model;
 
+import com.google.gson.JsonElement;
+import com.google.gson.annotations.SerializedName;
 import org.jetbrains.annotations.Nullable;
 
 public class ErrorResponse {
-    private final String error;
+    private final JsonElement error;
+
+    @SerializedName("user_error")
+    private final String userError;
+
     private final int requestId;
 
-    public ErrorResponse(final String error, final int requestId) {
+    public ErrorResponse(final JsonElement error, final String userError, final int requestId) {
         this.error = error;
+        this.userError = userError;
         this.requestId = requestId;
     }
 
     public @Nullable String error() {
-        return this.error;
-    }
+        if (this.userError != null) {
+            return this.userError;
+        } else if (this.error == null) {
+            return null;
+        }
 
-    public int requestId() {
-        return this.requestId;
+        return this.error.isJsonObject() ? this.error.getAsJsonObject().getAsJsonPrimitive("message").getAsString() : this.error.getAsString();
     }
 }

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/KeyPermissions.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/KeyPermissions.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.model;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class KeyPermissions {
+
+    private final Type type;
+    private final List<String> permissions;
+
+    public KeyPermissions(final Type type, final List<String> permissions) {
+        this.type = type;
+        this.permissions = permissions;
+    }
+
+    public Type type() {
+        return this.type;
+    }
+
+    public List<String> permissions() {
+        return this.permissions;
+    }
+
+    public enum Type {
+        @SerializedName("global")
+        GLOBAL,
+        @SerializedName("project")
+        PROJECT,
+        @SerializedName("organization")
+        ORGANIZATION;
+    }
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/Version.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/internal/model/Version.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.model;
+
+public class Version {
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/task/OreTask.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/task/OreTask.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.task;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.spongepowered.gradle.ore.internal.OreSession;
+import org.spongepowered.gradle.ore.internal.OreSessionService;
+
+import java.util.concurrent.CompletableFuture;
+
+public abstract class OreTask extends DefaultTask {
+
+    @Input
+    public abstract Property<String> getOreEndpoint();
+
+    @Input
+    public abstract Property<String> getOreApiKey();
+
+    @Internal
+    public abstract Property<OreSessionService> getOreSessions();
+
+    protected CompletableFuture<OreSession> session() {
+        return this.getOreSessions().get().session(
+            this.getOreApiKey().get(),
+            this.getOreEndpoint().get()
+        );
+    }
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/task/PublishToOreTask.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/task/PublishToOreTask.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of spongegradle-ore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.task;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.gradle.ore.OrePublication;
+import org.spongepowered.gradle.ore.internal.OreSession;
+import org.spongepowered.gradle.ore.internal.model.DeployVersionInfo;
+import org.spongepowered.gradle.ore.internal.model.Version;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Publish an artifact to the Ore plugin repository.
+ */
+public abstract class PublishToOreTask extends OreTask {
+
+    @Nested
+    public abstract Property<OrePublication> getPublication();
+
+    @TaskAction
+    public void doPublish() throws InterruptedException {
+        final CompletableFuture<OreSession> session = this.session();
+
+        final OrePublication pub = this.getPublication().get();
+        final File toPublish = pub.getPublishArtifacts().getSingleFile();
+        final boolean createForumPost = pub.getCreateForumPost().get();
+        final String versionBody = pub.getVersionBody().get();
+        final @Nullable String channel = pub.getChannel().getOrNull();
+
+        try {
+            final Version result = session.thenCompose(api -> {
+                return api.publishVersion(
+                    pub.getProjectId().get(),
+                    new DeployVersionInfo(
+                        versionBody,
+                        createForumPost,
+                        Collections.singletonMap("Channel", Collections.singletonList(channel))
+                    ),
+                    toPublish.toPath()
+                );
+            }).get();
+        } catch (ExecutionException e) {
+            throw new GradleException("Failed to publish to Ore: " + e.getMessage(), e.getCause());
+        }
+    }
+
+}

--- a/ore/src/main/java/org/spongepowered/gradle/ore/task/PublishToOreTask.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/task/PublishToOreTask.java
@@ -46,7 +46,7 @@ public abstract class PublishToOreTask extends OreTask {
     public abstract Property<OrePublication> getPublication();
 
     @TaskAction
-    public void doPublish() throws InterruptedException {
+    public void doPublish() {
         final CompletableFuture<OreSession> session = this.session();
 
         final OrePublication pub = this.getPublication().get();

--- a/ore/src/main/java/org/spongepowered/gradle/ore/task/PublishToOreTask.java
+++ b/ore/src/main/java/org/spongepowered/gradle/ore/task/PublishToOreTask.java
@@ -58,19 +58,22 @@ public abstract class PublishToOreTask extends OreTask {
         final @Nullable String channel = pub.getChannel().getOrNull();
 
         try {
-            final Version result = session.thenCompose(api -> {
-                return api.publishVersion(
-                    pub.getProjectId().get(),
-                    new DeployVersionInfo(
-                        versionBody,
-                        createForumPost,
-                        Collections.singletonMap("Channel", Collections.singletonList(channel))
-                    ),
-                    toPublish.toPath()
-                );
-            }).get();
+            // TODO: Log info about published version (like URL?)
+            final Version result = session.thenCompose(api -> api.publishVersion(
+                pub.getProjectId().get(),
+                new DeployVersionInfo(
+                    versionBody,
+                    createForumPost,
+                    Collections.singletonMap("Channel", Collections.singletonList(channel))
+                ),
+                toPublish.toPath()
+            )).get();
         } catch (ExecutionException e) {
-            throw new GradleException("Failed to publish to Ore: " + e.getMessage(), e.getCause());
+            if (e.getCause() instanceof GradleException) {
+                throw (GradleException) e.getCause();
+            } else {
+                throw new GradleException("Failed to publish to Ore: " + e.getMessage(), e.getCause());
+            }
         }
     }
 

--- a/ore/src/main/java9/org/spongepowered/gradle/ore/internal/http/TlsStrategyProvider.java
+++ b/ore/src/main/java9/org/spongepowered/gradle/ore/internal/http/TlsStrategyProvider.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of VanillaGradle, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.ore.internal.http;
+
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
+import org.apache.hc.core5.reactor.ssl.TlsDetails;
+
+// See main source set
+final class TlsStrategyProvider {
+    
+    private TlsStrategyProvider() {
+    }
+
+    static TlsStrategy provide() {
+        return ClientTlsStrategyBuilder.create()
+            .useSystemProperties()
+            .setTlsDetailsFactory(engine -> {
+                return new TlsDetails(engine.getSession(), engine.getApplicationProtocol());
+            })
+            .build();
+    }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,13 @@ dependencyResolutionManagement {
 
 rootProject.name = "SpongeGradle"
 
-sequenceOf("convention", "plugin-development", "repository", "testlib").forEach {
+sequenceOf(
+    "convention",
+    "plugin-development",
+    "ore",
+    "repository",
+    "testlib"
+).forEach {
     include(it)
     findProject(":$it")?.name = "${rootProject.name.toLowerCase(java.util.Locale.ROOT)}-$it"
 }


### PR DESCRIPTION
Add a plugin to publish artifacts to Ore.

This plugin has no direct dependency on the plugin development plugin, so it could be used with, say, ForgeGradle for people who want to publish forge mods, or to publish API 7 plugins that don't use the modern SpongeGradle.

A typical plugin author buildscript will have something like:

```kotlin
oreDeployment.defaultPublication {
      // channel.set("Release") // optional, if a non-default channel is wanted
      if (project.hasProperty("changelog")) {
        versionBody.set(file(project.property("changelog")!!).readText(Charsets.UTF_8))
    }
}
```

The full extension looks something like:

```kotlin
oreDeployment {
  oreEndpoint("https://ore.spongepowered.org/") // default
  apiKey().set(providers.environmentVariable("ORE_TOKEN")) // default value

  publications {
    named("default") {
      projectId.set("id")
      createForumPost.set(true) // default
      versionBody.set("") // default empty
      channel.set("Release") // default
      publishArtifacts.from(tasks.jar.map { it.outputs }) // default when SpongeGradle is present
    }
  }
}
```

Future work could make it easier to publish to multiple ore hosts, but this allows one project to have multiple artifacts published at least.