### PR TITLE
plugin-development: Compare only API major and minor version target

### DIFF
--- a/plugin-development/src/main/java/org/spongepowered/gradle/plugin/SpongePluginGradle.java
+++ b/plugin-development/src/main/java/org/spongepowered/gradle/plugin/SpongePluginGradle.java
@@ -151,7 +151,7 @@ public final class SpongePluginGradle implements ProjectOrSettingsPlugin {
         final int latestReleasedVersion = Math.max(Integer.parseInt(minorVersion) - 1, 0);
         // And then here, we determine if the api version still has a patch version, to just ignore it.
         final String latestReleasedApiMinor = isSnapshot ? String.valueOf(latestReleasedVersion) : minorVersion;
-        return apiMajor + "." + latestReleasedApiMinor + ".0";
+        return apiMajor + "." + latestReleasedApiMinor;
     }
 
     private void addApiDependency(final SpongePluginExtension sponge) {


### PR DESCRIPTION
Historically the API patch version has never lined up with the implementations.